### PR TITLE
replaced "structure_a" by "structure_b", line #1004

### DIFF
--- a/rmsd/calculate_rmsd.py
+++ b/rmsd/calculate_rmsd.py
@@ -1001,7 +1001,7 @@ Please see --help or documentation for more information.
         q_all += p_cent
 
         # done and done
-        xyz = set_coordinates(q_all_atoms, q_all, title="{} translated and rotated using rmsd".format(args.structure_a))
+        xyz = set_coordinates(q_all_atoms, q_all, title="{} translated and rotated using rmsd".format(args.structure_b))
         print(xyz)
 
     else:


### PR DESCRIPTION
Using the current master branch version 1.3.0 in Jimmy Charnley's repository, the

python calculate_rmsd.py -h

help reads like it is the second structure B that is aligned in respect to the other, and that
the newly generated coordinates of B were written by the optional -p parametr.  But the
*.xyz file actually written so far includes a header in the pattern of

modelA.xyz  translated and rotated using rmsd

as if model A was moved.  I find this at least irritating and hope this inconsistency spot
is limited to this very line in the optional output file written.